### PR TITLE
reset webGateway & tcpGateway

### DIFF
--- a/MIG/MIG/MIGService.cs
+++ b/MIG/MIG/MIGService.cs
@@ -180,6 +180,8 @@ namespace MIG
             }
             catch (Exception ex)
             {
+            	webGateway = new WebServiceGateway();
+                tcpGateway = new TcpSocketGateway();
                 // TODO: add error logging 
             }
             return success;


### PR DESCRIPTION
If port 80, the default we port is used the next port will be used 81, but when a web request comes in the "webGateway_ProcessRequest" function is getting called twice, not really sure why but re-initializing webGateway & tcpGateway makes sure that each URL request is processed only once
