### PR TITLE
Changed defaultWebFileEncoding to UTF-8

### DIFF
--- a/MIG/MIG/MIGService.cs
+++ b/MIG/MIG/MIGService.cs
@@ -109,7 +109,7 @@ namespace MIG
         //private TcpSocketGateway tcpGateway;
 
         //private int tcpGatewayPort = 4502;
-        private Encoding defaultWebFileEncoding = Encoding.GetEncoding("ISO-8859-1");
+        private Encoding defaultWebFileEncoding = Encoding.GetEncoding("UTF-8");
 
         private WebServiceGatewayConfiguration webServiceConfig;
 		// TODO: move webFileCache to WebServiceGateway.cs


### PR DESCRIPTION
Changed default encoding to solve the problem with titles of modules
written in Russian displays as «?????».
I found that module's names are written correctly in .xml file, but in UI they displays as a sequence of question marks. After investigating I found that MIGService responses to the client using defaultWebFileEncoding, which was Latin1 by default.
Also it solved the problem with "Weather underground" widget showed city name and current conditions with "????". See screenshots attached.
![2014-08-03 18 11 03](https://cloud.githubusercontent.com/assets/3062744/3790760/5e5ae00c-1b18-11e4-96ba-434a577fbcb6.png)
![2014-08-03 18 11 15](https://cloud.githubusercontent.com/assets/3062744/3790759/5e5abf5a-1b18-11e4-8352-ec53b3e04ac9.png)
