### PR TITLE
Moved some hard coded statistics settings to config file. Parameterized ...

### DIFF
--- a/BaseFiles/Common/html/js/api/homegenie.system.js
+++ b/BaseFiles/Common/html/js/api/homegenie.system.js
@@ -103,6 +103,19 @@ HG.System.WebCacheIsEnabled = function (callback) {
     });
 };
 
+// Should this be added to a new namespace like "HG.System.Statistics"? It's a setting, so thought it might not belong in homegenie.statstics.js... Opinions?
+HG.System.SetStatisticsDatabaseMaximumSize = function (mb, callback) {
+    $.ajax({
+        url: '/' + HG.WebApp.Data.ServiceKey + '/' + HG.WebApp.Data.ServiceDomain + '/Config/System.Configure/Statistics.SetStatisticsDatabaseMaximumSize/' + mb + '/' + (new Date().getTime()),
+        type: "POST",
+        data: "{ dummy: 'dummy' }",
+        dataType: "text",
+        success: function (data) {
+            if (callback != null) callback(data);
+        }
+    });
+};
+
 
 HG.System.UpdateManager = HG.System.UpdateManager || {};
 HG.System.UpdateManager.UpdateCheck = function (callback) {

--- a/BaseFiles/Common/html/pages/analyze/_statistics.js
+++ b/BaseFiles/Common/html/pages/analyze/_statistics.js
@@ -11,7 +11,7 @@ HG.WebApp.Statistics._RefreshIntervalObject = null;
 HG.WebApp.Statistics._RefreshInterval = 2 * 60000; // stats refresh interval = 2 minutes
 //
 HG.WebApp.Statistics.InitializePage = function () {
-
+    HG.WebApp.Statistics.InitConfiguration();
     $('#page_analyze_source').on('change', function () {
         var selected = $(this).find('option:selected');
         var filter = selected.attr('data-context-domain') + ':' + selected.attr('data-context-address');
@@ -162,6 +162,14 @@ HG.WebApp.Statistics.SetAutoRefresh = function (autorefresh) {
     }
 };
 
+HG.WebApp.Statistics.InitConfiguration = function () {
+    HG.Statistics.ServiceCall('Configuration.Get', '', '', function (configs) {
+        var setting = eval(configs)[0];
+        var sec = (setting.StatisticsUIRefreshSeconds * 1);
+        HG.WebApp.Statistics._RefreshInterval = sec * 1000; //2 * 60000;
+        HG.WebApp.Statistics.SetAutoRefresh(true);
+    });
+}
 
 HG.WebApp.Statistics.RefreshParameters = function (filter) {
     var cval = $('#page_analyze_param').val();

--- a/BaseFiles/Common/html/pages/configure/maintenance/_maintenance.js
+++ b/BaseFiles/Common/html/pages/configure/maintenance/_maintenance.js
@@ -263,6 +263,17 @@ HG.WebApp.Maintenance.InitializePage = function () {
             });
         });
 
+        $('#systemsettings_databasemaxsize_change').bind('click', function () {
+            var sizemb = $('#systemsettings_databasemaxsizechange_size').val();
+            $.mobile.loading('show');
+            HG.System.SetStatisticsDatabaseMaximumSize(sizemb, function (data) {
+                $.mobile.loading('hide');
+                setTimeout(function () {
+                    HG.WebApp.Maintenance.LoadStatisticsSettings();
+                }, 1000);
+            });
+        });
+
     });
 };
 
@@ -285,6 +296,7 @@ HG.WebApp.Maintenance.LoadSettings = function () {
         $.mobile.loading('hide');
     });
     //
+    HG.WebApp.Maintenance.LoadStatisticsSettings();
     HG.WebApp.Maintenance.LoadSecuritySettings();
     HG.WebApp.Maintenance.LoadUpdateCheckSettings();
     //
@@ -333,6 +345,15 @@ HG.WebApp.Maintenance.LoadSecuritySettings = function () {
             $('#configure_system_flip_httpcache').val(data).slider('refresh');
             $.mobile.loading('hide');
         });
+    });
+};
+
+HG.WebApp.Maintenance.LoadStatisticsSettings = function () {
+    $.mobile.loading('show');
+    HG.Configure.System.ServiceCall("Statistics.GetStatisticsDatabaseMaximumSize", function (data) {
+        $('#systemsettings_databasemaxsizechange_size').val(data);
+        $('#systemsettings_databasemaxsize_text').html(data);
+        $.mobile.loading('hide');
     });
 };
 

--- a/BaseFiles/Common/html/pages/configure/maintenance/main.html
+++ b/BaseFiles/Common/html/pages/configure/maintenance/main.html
@@ -119,19 +119,21 @@
                     </div>
                 </div>
             </li>
-            <li>
-                <div class="ui-grid-a">
-                    <div class="ui-block-a">
-                        <div>
-                            <label data-locale-id="configure_system_statistics">Statistics</label><br />
-                        </div>
-                    </div>
-                    <div class="ui-block-b" style="float:right;width:150px">
-                        <a class="ui-btn ui-corner-all" data-locale-id="configure_system_databasereset" href="javascript:HG.Statistics.Database.Reset()">Database Reset</a>
+            <!--
+        <li>
+            <div class="ui-grid-a">
+                <div class="ui-block-a">
+                    <div>
+                        <label data-locale-id="configure_system_statistics">Statistics</label><br />
                     </div>
                 </div>
+                <div class="ui-block-b" style="float:right;width:150px">
+                    <a class="ui-btn ui-corner-all" data-locale-id="configure_system_databasereset" href="javascript:HG.Statistics.Database.Reset()">Database Reset</a>
+                </div>
+            </div>
 
-            </li>
+        </li>
+            -->
             <li>
                 <div class="ui-grid-a">
                     <div class="ui-block-a">
@@ -158,6 +160,52 @@
                 </div>
 
             </li>
+
+            <li data-locale-id="configure_system_statistics" data-role="list-divider">Statistics</li>
+            <li>
+                <div class="ui-grid-a">
+                    <div>
+                        <label data-locale-id="configure_system_statistics_clear">Clear All Statistics Data</label><br />
+                    </div>
+                    <div class="ui-block-b" style="float:right;width:150px">
+                        <!-- TODO: Confirmation for this?-->
+                        <a class="ui-btn ui-corner-all" data-locale-id="configure_system_databasereset" href="javascript:HG.Statistics.Database.Reset()">Reset</a>
+                    </div>
+                </div>
+
+            </li>
+            <li>
+                <div class="ui-grid-a">
+                    <div class="ui-block-a">
+                        <div>
+                            <label><span data-locale-id="configure_system_statistics_databasemaxsize">Maximum Database Size is </span><span id="systemsettings_databasemaxsize_text"></span> MB</label><br />
+                        </div>
+                    </div>
+                    <div class="ui-block-b" style="float:right;width:150px">
+                        <a href="#systemsettings_databasemaxsizechange_popup" data-locale-id="configure_system_statistics_changedatabasemaxsize" data-rel="popup" class="ui-btn ui-corner-all">Change</a>
+                    </div>
+                </div>
+
+            </li>
+            
+
+            <!-- Might be dangerous for average user without constraints? Hiding for now...
+            <li>
+                <div class="ui-grid-a">
+                    <div class="ui-block-a">
+                        <div>
+                            <label><span data-locale-id="configure_system_statistics_timeresolution">Record statistics every</span> <span id="systemsettings_statistics_timeresolutionseconds_text"></span> <span data-locale-id="configure_system_statistics_timeresolution_units">seconds</span></label><br />
+                        </div>
+                    </div>
+                    <div class="ui-block-b" style="float:right;width:150px">
+                        <a href="#systemsettings_databasemaxsizechange_popup" data-locale-id="configure_system_statistics_changetimeresolution" data-rel="popup" class="ui-btn ui-corner-all">Change Size</a>
+                    </div>
+                </div>
+
+            </li>
+        -->
+
+
             <li data-locale-id="configure_system_userinterface" data-role="list-divider">User Interface</li>
             <li>
                 <span data-locale-id="configure_system_theme">Theme</span>
@@ -341,6 +389,54 @@
                 </div>
             </div>
         </div>
+        
+        <div id="systemsettings_databasemaxsizechange_popup" class="ui-corner-all hg-popup-a" data-role="popup" data-position-to="window" data-transition="pop" data-overlay-theme="b">
+            <div data-role="header" class="ui-corner-top">
+                <h1 data-locale-id="configure_system_statistics_databasemaxsizechange">Maximum Size (MB)</h1>
+            </div>
+
+            <div class="ui-corner-bottom ui-content">
+                <h3 data-locale-id="configure_system_statistics_databasemaxsizechange_note" class="ui-title">Note: after changing size, HomeGenie must be restarted to make changes effective!</h3>
+                <p>
+                    <label for="systemsettings_databasemaxsizechange_size" />
+                    <input id="systemsettings_databasemaxsizechange_size" type="number" />
+                </p>
+                <div class="ui-grid-a">
+                    <div class="ui-block-a">
+                        <a href="#" class="ui-btn ui-corner-all" data-locale-id="configure_system_statistics_databasemaxsizechange_cancel" data-rel="back">Cancel</a>
+                    </div>
+                    <div class="ui-block-b">
+                        <a id="systemsettings_databasemaxsize_change" href="#" class="ui-btn ui-corner-all" data-locale-id="configure_system_statistics_databasemaxsizechange_commit" data-rel="back" data-transition="flow">Change</a>
+                    </div>
+                </div>
+            </div>
+        </div>
+        
+        <!--
+        <div id="systemsettings_statistics_timeresolutionseconds_popup" class="ui-corner-all hg-popup-a" data-role="popup" data-position-to="window" data-transition="pop" data-overlay-theme="b">
+            <div data-role="header" class="ui-corner-top">
+                <h1 data-locale-id="configure_system_statistics_timeresolutionchange">Statistics Record Interval</h1>
+            </div>
+
+            <div class="ui-corner-bottom ui-content">
+                <h3 data-locale-id="configure_system_statistics_timeresolutionchange_note" class="ui-title">Note: after changing interval, HomeGenie must be restarted to make changes effective!</h3>
+                <p>
+                    <label for="systemsettings_statistics_timeresolutionchange_seconds" />
+                    <input id="systemsettings_statistics_timeresolutionchange_seconds" type="number" />
+                </p>
+                <div class="ui-grid-a">
+                    <div class="ui-block-a">
+                        <a href="#" class="ui-btn ui-corner-all" data-locale-id="configure_system_statistics_timeresolutionchange_cancel" data-rel="back">Cancel</a>
+                    </div>
+                    <div class="ui-block-b">
+                        <a id="systemsettings_statistics_timeresolution_change" href="#" class="ui-btn ui-corner-all" data-locale-id="configure_system_statistics_timeresolutionchange_commit" data-rel="back" data-transition="flow">Change</a>
+                    </div>
+                </div>
+            </div>
+        </div>
+        -->
+        
+        
 
     </div>
     <div data-role="footer" data-position="fixed" data-tap-toggle="false">

--- a/HomeGenie/Data/SystemConfiguration.cs
+++ b/HomeGenie/Data/SystemConfiguration.cs
@@ -157,6 +157,58 @@ namespace HomeGenie.Data
         public string GUID { get; set; }
 
         public string EnableLogFile { get; set; }
+
+        public StatisticsConfiguration Statistics = new StatisticsConfiguration();
+
+        [Serializable()]
+        public class StatisticsConfiguration
+        {
+
+            [XmlAttribute]
+            public int MaxDatabaseSizeMBytes { get; set; }
+
+            [XmlAttribute]
+            public int StatisticsTimeResolutionSeconds { get; set; }
+
+            [XmlAttribute]
+            public int StatisticsUIRefreshSeconds { get; set; }
+
+            public StatisticsConfiguration()
+            {
+
+                MaxDatabaseSizeMBytes = 10; // 10MB default.
+                StatisticsTimeResolutionSeconds = 5 * 60; // 5 minute default.
+                StatisticsUIRefreshSeconds = 2 * 60; // 2 minute default.
+            }
+
+            /// <summary>
+            /// Set constraints to protect the system. These are absolute constraints to protect the user experience (locked browser/server), but are not 
+            /// RECOMMENDED constraints. For example, StatisticsTimeResolutionSeconds less than 5*60 starts to make the graph 
+            /// look messy, but we still allow anything above 30 seconds in case advanced user wants it. Might want to keep 
+            /// recommended values reference later.
+            /// 
+            /// Should later throw error so UI can notify user?
+            /// </summary>
+            public void Validate()
+            {
+                // 
+                if (MaxDatabaseSizeMBytes < 1)
+                {
+                    MaxDatabaseSizeMBytes = 1;
+                }
+                // Current design would make < 30 seconds a poor setting. In full day view, if this is anything less than a few minutes, day detail line is smashed.
+                if (StatisticsTimeResolutionSeconds < 30)
+                {
+                    StatisticsTimeResolutionSeconds = 30;
+                }
+                if (StatisticsUIRefreshSeconds < 5)
+                {
+                    StatisticsUIRefreshSeconds = 5;
+                }
+
+            }
+
+        }
     }
 
 }

--- a/HomeGenie/Service/Handlers/Config.cs
+++ b/HomeGenie/Service/Handlers/Config.cs
@@ -203,6 +203,21 @@ namespace HomeGenie.Service.Handlers
                     {
                     }
                 }
+                else if (migCommand.GetOption(0) == "Statistics.GetStatisticsDatabaseMaximumSize")
+                {
+                    migCommand.Response = JsonHelper.GetSimpleResponse(homegenie.SystemConfiguration.HomeGenie.Statistics.MaxDatabaseSizeMBytes.ToString());
+                }
+                else if (migCommand.GetOption(0) == "Statistics.SetStatisticsDatabaseMaximumSize")
+                {
+                    try
+                    {
+                        homegenie.SystemConfiguration.HomeGenie.Statistics.MaxDatabaseSizeMBytes = int.Parse(migCommand.GetOption(1));
+                        homegenie.SystemConfiguration.Update();
+                    }
+                    catch
+                    {
+                    }
+                }
                 else if (migCommand.GetOption(0) == "SystemLogging.DownloadCsv")
                 {
                     string csvlog = "";

--- a/HomeGenie/Service/Handlers/Statistics.cs
+++ b/HomeGenie/Service/Handlers/Statistics.cs
@@ -60,7 +60,10 @@ namespace HomeGenie.Service.Handlers
             case "Database.Reset":
                 homegenie.Statistics.DatabaseReset();
                 break;
-
+            case "Configuration.Get":
+                // Just one at the moment.
+                migCommand.Response = "[{ StatisticsUIRefreshSeconds : '" + homegenie.SystemConfiguration.HomeGenie.Statistics.StatisticsUIRefreshSeconds + "' }]";
+                break;
             case "Parameter.List":
                 filterList = migCommand.GetOption(0).Split(':');
                 if (filterList.Length == 2)

--- a/HomeGenie/Service/Logging/StatisticsLogger.cs
+++ b/HomeGenie/Service/Logging/StatisticsLogger.cs
@@ -72,14 +72,17 @@ namespace HomeGenie.Service.Logging
         private SQLiteConnection dbConnection;
 
         //private object dbLock = new object();
-        private long dbSizeLimit = 5242880 * 2;
-
-        private static int STATISTICS_TIME_RESOLUTION_MINUTES = 5;
+        private readonly long dbSizeLimit = 5242880 * 2;
+        //private static int STATISTICS_TIME_RESOLUTION_MINUTES = 5;
+        private readonly int _statisticsTimeResolutionSeconds = 5 * 60;
 
         public StatisticsLogger(HomeGenieService hg)
         {
             homegenie = hg;
-            logInterval = new Timer(TimeSpan.FromMinutes(STATISTICS_TIME_RESOLUTION_MINUTES).TotalMilliseconds);
+            dbSizeLimit = hg.SystemConfiguration.HomeGenie.Statistics.MaxDatabaseSizeMBytes * 1024 * 1024;
+            _statisticsTimeResolutionSeconds = hg.SystemConfiguration.HomeGenie.Statistics.StatisticsTimeResolutionSeconds;
+
+            logInterval = new Timer(TimeSpan.FromSeconds(_statisticsTimeResolutionSeconds).TotalMilliseconds);
             logInterval.Elapsed += logInterval_Elapsed;
         }
 
@@ -102,13 +105,17 @@ namespace HomeGenie.Service.Logging
 
         public List<string> GetParametersList(string domain, string address)
         {
-            string filter = "";
-            if (domain != "" && address != "") filter = " where Domain ='" + domain + "' and Address = '" + address + "'";
             var parameterList = new List<string>();
             //lock (dbLock)
             {
                 var dbCommand = dbConnection.CreateCommand();
-                string query = "select distinct Parameter from ValuesHist" + filter;
+                string query = "select distinct Parameter from ValuesHist";
+                if (!string.IsNullOrEmpty(domain) && !string.IsNullOrEmpty(address))
+                {
+                    query += " WHERE Domain=@domain AND Address=@address ";
+                    dbCommand.Parameters.Add(new SQLiteParameter("@domain", domain));
+                    dbCommand.Parameters.Add(new SQLiteParameter("@address", address));
+                }
                 dbCommand.CommandText = query;
                 var reader = dbCommand.ExecuteReader();
                 while (reader.Read())
@@ -155,7 +162,8 @@ namespace HomeGenie.Service.Logging
             {
                 var dbCommand = dbConnection.CreateCommand();
                 // TODO: protect against sqlinjection ?
-                string query = "select Sum(AverageValue*( ((julianday(TimeEnd) - 2440587.5) * 86400.0) -((julianday(TimeStart) - 2440587.5) * 86400.0) )/" + timeScaleSeconds.ToString(System.Globalization.CultureInfo.InvariantCulture) + ") as CounterValue from ValuesHist where Parameter = '" + parameterName + "';";
+                string query = "select Sum(AverageValue*( ((julianday(TimeEnd) - 2440587.5) * 86400.0) -((julianday(TimeStart) - 2440587.5) * 86400.0) )/" + timeScaleSeconds.ToString(System.Globalization.CultureInfo.InvariantCulture) + ") as CounterValue from ValuesHist where Parameter = @parameterName;";
+                dbCommand.Parameters.Add(new SQLiteParameter("@parameterName", parameterName));
                 dbCommand.CommandText = query;
                 var reader = dbCommand.ExecuteReader();
                 //
@@ -190,8 +198,14 @@ namespace HomeGenie.Service.Logging
             {
                 var dbCommand = dbConnection.CreateCommand();
                 string filter = "";
-                if (domain != "" && address != "") filter = "Domain ='" + domain + "' and Address = '" + address + "' and ";
-                string query = "select TimeStart,TimeEnd,Domain,Address,Sum(AverageValue*( ((julianday(TimeEnd) - 2440587.5) * 86400.0) -((julianday(TimeStart) - 2440587.5) * 86400.0) )/" + timescaleseconds.ToString(System.Globalization.CultureInfo.InvariantCulture) + ") as CounterValue from ValuesHist where " + filter + "Parameter = '" + parameterName + "' AND " + GetDateRangeFilter(startDate, endDate) + " group by Domain, Address, strftime('%H', TimeStart) order by TimeStart desc;";
+                if (!string.IsNullOrEmpty(domain) && !string.IsNullOrEmpty(address))
+                {
+                    filter= " Domain=@domain AND Address=@address and ";
+                    dbCommand.Parameters.Add(new SQLiteParameter("@domain", domain));
+                    dbCommand.Parameters.Add(new SQLiteParameter("@address", address));
+                }
+                string query = "select TimeStart,TimeEnd,Domain,Address,Sum(AverageValue*( ((julianday(TimeEnd) - 2440587.5) * 86400.0) -((julianday(TimeStart) - 2440587.5) * 86400.0) )/" + timescaleseconds.ToString(System.Globalization.CultureInfo.InvariantCulture) + ") as CounterValue from ValuesHist where " + filter + " Parameter = @parameterName AND " + GetParameterizedDateRangeFilter(ref dbCommand,startDate, endDate) + " group by Domain, Address, strftime('%H', TimeStart) order by TimeStart desc;";
+                dbCommand.Parameters.Add(new SQLiteParameter("@parameterName", parameterName));
                 dbCommand.CommandText = query;
                 var reader = dbCommand.ExecuteReader();
                 //
@@ -224,6 +238,14 @@ namespace HomeGenie.Service.Logging
             return values;
         }
 
+        /// <summary>
+        /// This is for the current day's AVERAGES part: (TODAY_AVG)
+        /// </summary>
+        /// <param name="domain"></param>
+        /// <param name="address"></param>
+        /// <param name="parameterName"></param>
+        /// <param name="aggregator"></param>
+        /// <returns></returns>
         public List<StatisticsEntry> GetHourlyStatsToday(
             string domain,
             string address,
@@ -237,9 +259,17 @@ namespace HomeGenie.Service.Logging
                 var dbCommand = dbConnection.CreateCommand();
                 string filter = "";
                 var start = DateTime.Parse(DateTime.Now.ToString("yyyy-MM-dd") + " 00:00:00.000000");
-                if (domain != "" && address != "") filter = "Domain ='" + domain + "' and Address = '" + address + "' and ";
+                dbCommand.Parameters.Add(new SQLiteParameter("@start", start.ToUniversalTime().ToString("yyyy-MM-dd HH:mm:ss.ffffff") ));
+                //if (domain != "" && address != "") filter = "Domain ='" + domain + "' and Address = '" + address + "' and ";
+                if (!string.IsNullOrEmpty(domain) && !string.IsNullOrEmpty(address))
+                {
+                    filter = " Domain=@domain AND Address=@address and ";
+                    dbCommand.Parameters.Add(new SQLiteParameter("@domain", domain));
+                    dbCommand.Parameters.Add(new SQLiteParameter("@address", address));
+                }
+                dbCommand.Parameters.Add(new SQLiteParameter("@parameterName", parameterName));
                 // aggregated averages by hour
-                string query = "select TimeStart,TimeEnd,Domain,Address," + aggregator + "(AverageValue) as Value from ValuesHist where " + filter + "Parameter = '" + parameterName + "' and TimeStart >= '" + start.ToUniversalTime().ToString("yyyy-MM-dd HH:mm:ss.ffffff") + "' group by Domain, Address, strftime('%H', TimeStart)  order by TimeStart asc;";
+                string query = "select TimeStart,TimeEnd,Domain,Address," + aggregator + "(AverageValue) as Value from ValuesHist where " + filter + "Parameter = @parameterName and TimeStart >= @start group by Domain, Address, strftime('%H', TimeStart)  order by TimeStart asc;";
                 dbCommand.CommandText = query;
                 SQLiteDataReader reader = dbCommand.ExecuteReader();
                 //
@@ -272,7 +302,6 @@ namespace HomeGenie.Service.Logging
             return values;
         }
 
-
         public List<StatisticsEntry> GetTodayDetail(
             string domain,
             string address,
@@ -285,20 +314,53 @@ namespace HomeGenie.Service.Logging
             {
                 var dbCommand = dbConnection.CreateCommand();
                 string filter = "";
+                string groupBy = "";
                 var start = DateTime.Parse(DateTime.Now.ToString("yyyy-MM-dd") + " 00:00:00.000000");
-                if (domain != "" && address != "") filter = "Domain ='" + domain + "' and Address = '" + address + "' and ";
+                dbCommand.Parameters.Add(new SQLiteParameter("@start", start.ToUniversalTime().ToString("yyyy-MM-dd HH:mm:ss.ffffff"))); 
+                
+                if (!string.IsNullOrEmpty(domain) && !string.IsNullOrEmpty(address))
+                {
+                    // detailed module stats. We set our own aggregator. (Detailed red line in chart)
+                    filter = " Domain=@domain AND Address=@address and ";
+                    dbCommand.Parameters.Add(new SQLiteParameter("@domain", domain));
+                    dbCommand.Parameters.Add(new SQLiteParameter("@address", address));
+                    aggregator = "AverageValue";
+                }
+                else
+                {
+                    // aggregated averages by hour
+                    if (!string.IsNullOrEmpty(aggregator))
+                    {
+                        aggregator = aggregator + "(AverageValue)";
+                    }
+                    groupBy = "group by TimeStart";
+                }
+                string query = "select TimeStart,TimeEnd,Domain,Address," + aggregator + " as Value from ValuesHist where " + filter + " Parameter = @parameterName AND TimeStart >= @start " + groupBy + " order by TimeStart asc;";
+                dbCommand.Parameters.Add(new SQLiteParameter("@parameterName", parameterName));
+                dbCommand.CommandText = query;
+
+                /*
+                //if (domain != "" && address != "") filter = "Domain ='" + domain + "' and Address = '" + address + "' and ";
                 // aggregated averages by hour
-                string q = "select TimeStart,TimeEnd,Domain,Address," + aggregator + "(AverageValue) as Value from ValuesHist where " + filter + "Parameter = '" + parameterName + "' and TimeStart >= '" + start.ToUniversalTime().ToString("yyyy-MM-dd HH:mm:ss.ffffff") + "' group by TimeStart order by TimeStart asc;";
+                string q = "select TimeStart,TimeEnd,Domain,Address," + aggregator + "(AverageValue) as Value from ValuesHist where " + filter + "Parameter = @parameterName and TimeStart >= @start group by TimeStart order by TimeStart asc;";
                 // detailed module stats
                 if (domain != "" && address != "")
                 {
                     q = "select TimeStart,TimeEnd,Domain,Address,AverageValue as Value from ValuesHist where " + filter + "Parameter = '" + parameterName + "' and TimeStart >= '" + start.ToUniversalTime().ToString("yyyy-MM-dd HH:mm:ss.ffffff") + "' order by TimeStart asc;";
                 }
-                dbCommand.CommandText = q;
+                dbCommand.CommandText = q;*/
+
                 var reader = dbCommand.ExecuteReader();
                 //
                 while (reader.Read())
                 {
+                    // If nothing is found in filter during aggregate, we get a row of all DBNulls. Skip the entry.
+                    // NOTE: We got an exception before this check if HG sends a request for a param that has no results 
+                    //       for the Parameter/TimeStart filter. We got single row of all DBNulls. 
+                    if (reader.IsDBNull(0))
+                    {
+                        continue;
+                    }
                     var entry = new StatisticsEntry();
                     entry.TimeStart = DateTime.Parse(reader.GetString(0));
                     entry.TimeEnd = DateTime.Parse(reader.GetString(1));
@@ -326,6 +388,16 @@ namespace HomeGenie.Service.Logging
             return values;
         }
 
+        /// <summary>
+        /// This is for the overall AVERAGES part: (MIN), (MAX), (AVG)
+        /// </summary>
+        /// <param name="domain"></param>
+        /// <param name="address"></param>
+        /// <param name="parameterName"></param>
+        /// <param name="aggregator"></param>
+        /// <param name="startDate"></param>
+        /// <param name="endDate"></param>
+        /// <returns></returns>
         public List<StatisticsEntry> GetHourlyStats(
             string domain,
             string address,
@@ -339,8 +411,18 @@ namespace HomeGenie.Service.Logging
             {
                 var dbCommand = dbConnection.CreateCommand();
                 string filter = "";
-                if (domain != "" && address != "") filter = "Domain ='" + domain + "' and Address = '" + address + "' and ";
-                string query = "select TimeStart,TimeEnd,Domain,Address," + aggregator + "(AverageValue) as Value from ValuesHist where " + filter + "Parameter = '" + parameterName + "' AND " + GetDateRangeFilter(startDate, endDate) + " group by Domain, Address, strftime('%H', TimeStart)  order by TimeStart asc;";
+
+                if (!string.IsNullOrEmpty(domain) && !string.IsNullOrEmpty(address))
+                {
+                    filter = " Domain=@domain AND Address=@address and ";
+                    dbCommand.Parameters.Add(new SQLiteParameter("@domain", domain));
+                    dbCommand.Parameters.Add(new SQLiteParameter("@address", address));
+                }
+                string query = "select TimeStart,TimeEnd,Domain,Address," + aggregator + "(AverageValue) as Value from ValuesHist where " + filter + " Parameter = @parameterName AND " + GetParameterizedDateRangeFilter(ref dbCommand, startDate, endDate) + " group by Domain, Address, strftime('%H', TimeStart)  order by TimeStart asc;";
+                dbCommand.Parameters.Add(new SQLiteParameter("@parameterName", parameterName));
+
+                //if (domain != "" && address != "") filter = "Domain ='" + domain + "' and Address = '" + address + "' and ";
+                //string query = "select TimeStart,TimeEnd,Domain,Address," + aggregator + "(AverageValue) as Value from ValuesHist where " + filter + "Parameter = '" + parameterName + "' AND " + GetDateRangeFilter(startDate, endDate) + " group by Domain, Address, strftime('%H', TimeStart)  order by TimeStart asc;";
                 dbCommand.CommandText = query;
                 var reader = dbCommand.ExecuteReader();
                 //
@@ -403,7 +485,50 @@ namespace HomeGenie.Service.Logging
                 dbCommand.ExecuteNonQuery();
             }
         }
+        /// <summary>
+        /// Removes older values to keep DB size within configured size limit. Currently just cuts out last half of dates.
+        /// </summary>
+        private void CleanOldValuesFromStatisticsDatabase()
+        {
+            // + NUM_DAYS = Find number of days stored in DB.
+            var stat = GetDateRange();
+            int numDays = DateTime.Now.Subtract(stat.TimeStart).Days;
+            int numDaysRemove = (int)Math.Floor(numDays / 2d);
+            // + NUM_RECORDS = Get number of records.
+            // + NUM_RECORDS_PER_DAY = Divide number of records by days to get records per day. (Not needed yet)
 
+            // +++ We ultiumately want to shrink DB size by 50% or so...
+            //     Just divide NUM_DAYS by 2. That should handle most cases.
+            CleanOldValuesFromStatisticsDatabase(numDaysRemove);
+
+        }
+
+        /// <summary>
+        /// Removes older values to keep DB size within configured size limit.
+        /// </summary>
+        /// <param name="numberOfDays">Records older than this number of days are removed.</param>
+        private void CleanOldValuesFromStatisticsDatabase(int numberOfDays)
+        {
+            if (numberOfDays > 0)
+            {
+                //lock (dbLock)
+                {
+                    var dbCommand = dbConnection.CreateCommand();
+                    dbCommand.CommandText = "DELETE FROM ValuesHist WHERE TimeStart < DATEADD(dd,-" + numberOfDays + ",GETDATE());";
+                    dbCommand.ExecuteNonQuery();
+                    dbCommand.CommandText = "VACUUM";
+                    dbCommand.ExecuteNonQuery();
+
+                    HomeGenieService.LogEvent(
+                                       Domains.HomeAutomation_HomeGenie,
+                                       "Service.StatisticsLogger",
+                                       "Cleaned old values from database.",
+                                       "DayThreshold",
+                                       numberOfDays.ToString()
+                                   );
+                }
+            }
+        }
         private void CloseStatisticsDatabase()
         {
             //lock (dbLock)
@@ -418,6 +543,15 @@ namespace HomeGenie.Service.Logging
             var d2 = DateTime.Parse(end.ToString("yyyy-MM-dd") + " 23:59:59.999999");
             var filter = "(TimeStart >= '" + d1.ToUniversalTime().ToString("yyyy-MM-dd HH:mm:ss.ffffff") + "' AND TimeStart <= '" + d2.ToUniversalTime().ToString("yyyy-MM-dd HH:mm:ss.ffffff") + "')";
             return filter;
+        }
+
+        private string GetParameterizedDateRangeFilter(ref SQLiteCommand dbCommand, DateTime start, DateTime end)
+        {
+            var d1 = DateTime.Parse(start.ToString("yyyy-MM-dd") + " 00:00:00.000000");
+            var d2 = DateTime.Parse(end.ToString("yyyy-MM-dd") + " 23:59:59.999999");
+            dbCommand.Parameters.Add(new SQLiteParameter("@timeStartMin", d1.ToUniversalTime().ToString("yyyy-MM-dd HH:mm:ss.ffffff")));
+            dbCommand.Parameters.Add(new SQLiteParameter("@timeStartMax", d2.ToUniversalTime().ToString("yyyy-MM-dd HH:mm:ss.ffffff")));
+            return "(TimeStart >= @timeStartMin  AND TimeStart <= @timeStartMax)";
         }
 
         private string GetStatisticsDatabaseName()
@@ -456,6 +590,8 @@ namespace HomeGenie.Service.Logging
                             if (fileInfo.Length > dbSizeLimit) // 5Mb limit for stats - temporary limitations to get rid of in the future
                             {
                                 ResetStatisticsDatabase();
+                                // TODO: Test method below, then use that instead of rsetting whole database.
+                                //CleanOldValuesFromStatisticsDatabase();
                             }
                             //
                             try


### PR DESCRIPTION
...DB queries to prevent SQL injection. Added method that attempts to cut db size instead of full reset when size limit exceeded (Not enabled until tested). UI support for new config settings (excluding stats record interval until discussed).

These changes have been tested locally in my dev instance. All statistics methods appear to be working as expected. New settings are set to defaults (defaults being original hard-coded values).