### PR TITLE
change the command type for Alarm handler

### DIFF
--- a/MigFiles/SupportLibraries/ZWaveLib/Handlers/Alarm.cs
+++ b/MigFiles/SupportLibraries/ZWaveLib/Handlers/Alarm.cs
@@ -32,7 +32,7 @@ namespace ZWaveLib.Handlers
         {
             ZWaveEvent nodeEvent = null;
             byte cmdType = message[8];
-            if (cmdType == (byte)Command.SensorAlarmReport)
+            if (cmdType == (byte)Command.AlarmReport)
             {
                 var alarm = AlarmValue.Parse(message);
                 nodeEvent = new ZWaveEvent(node, alarm.EventType, alarm.Value, 0);


### PR DESCRIPTION
Hello,

While testing that the tag reader was still ok after the zwave-rework (#124), I had to change this line to get it work. I think this is an error introduced by the zwave-rework.

Regards
Alexandre Schnegg