### PR TITLE
re-add  removed functionality

### DIFF
--- a/BaseFiles/Common/html/pages/control/widgets/homegenie/generic/doorlock.js
+++ b/BaseFiles/Common/html/pages/control/widgets/homegenie/generic/doorlock.js
@@ -40,15 +40,14 @@
                 this.UpdateTime = HG.WebApp.Utility.FormatDate(d) + ' ' + HG.WebApp.Utility.FormatDateTime(d);
             }
 	    }
-
-        if (lockstatus != null && lockstatus.Value == '255') { // 0xFF
-            widget.find('[data-ui-field=lockunlock]').val("locked").slider('refresh');
+        if (lockstatus != null && lockstatus.Value == 'Secured') { // 0xFF
+            widget.find('[data-ui-field=lockunlock]').val("Secured").slider('refresh');
             this.IconImage = 'pages/control/widgets/homegenie/generic/images/door_closed.png';
             this.StatusText = "Locked";
         } else {
-            widget.find('[data-ui-field=lockunlock]').val("unlocked").slider('refresh');
+            widget.find('[data-ui-field=lockunlock]').val("Unsecured").slider('refresh');
             this.IconImage = 'pages/control/widgets/homegenie/generic/images/door_open.png';
-            this.StatusText = "Unocked";
+            this.StatusText = "Unlocked";
         }
 
         this.Description = (module.Domain.substring(module.Domain.lastIndexOf('.') + 1)) + ' ' + module.Address;

--- a/BaseFiles/Common/html/pages/control/widgets/homegenie/generic/doorlock.js
+++ b/BaseFiles/Common/html/pages/control/widgets/homegenie/generic/doorlock.js
@@ -4,7 +4,7 @@
     Version: "2015-04-07",
 
     GroupName: '',
-    IconImage : 'pages/control/widgets/homegenie/generic/images/door_closed.png',
+    IconImage: 'pages/control/widgets/homegenie/generic/images/door_closed.png',
     StatusText: '',
     Description: '',
     UpdateTime: '',
@@ -12,7 +12,7 @@
     RenderView: function (cuid, module) {
         var container = $(cuid);
         var widget = container.find('[data-ui-field=widget]');
-        
+
         //
         if (!this.Initialized) {
             this.Initialized = true;
@@ -31,16 +31,27 @@
         this.GroupName = container.attr('data-context-group');
 
         var lockstatus = HG.WebApp.Utility.GetModulePropertyByName(module, "Status.DoorLock");
+        var lockalarm = HG.WebApp.Utility.GetModulePropertyByName(module, "Sensor.Alarm");
 
-        if (lockstatus != null) {
-            var l_updateTime = lockstatus.UpdateTime;
+        var triggeredEvent;
+
+        if (lockstatus != null)
+            triggeredEvent = lockstatus;
+
+        if (lockalarm != null && lockalarm.UpdateTime > lockstatus.UpdateTime)
+            triggeredEvent = lockalarm;
+
+        if (triggeredEvent != null) {
+            var l_updateTime = triggeredEvent.UpdateTime;
+
             if (typeof l_updateTime != 'undefined') {
                 l_updateTime = l_updateTime.replace(' ', 'T'); // fix for IE and FF
                 var d = new Date(l_updateTime);
                 this.UpdateTime = HG.WebApp.Utility.FormatDate(d) + ' ' + HG.WebApp.Utility.FormatDateTime(d);
             }
-	    }
-        if (lockstatus != null && lockstatus.Value == 'Secured') { // 0xFF
+        }
+
+        if (triggeredEvent != null && (triggeredEvent.Name == "DoorLock.Status" && triggeredEvent.Value == 'Secured') || (triggeredEvent.Name == "Sensor.Alarm" && (triggeredEvent.Value == 1 || triggeredEvent.Value == 5))) { // 0xFF
             widget.find('[data-ui-field=lockunlock]').val("Secured").slider('refresh');
             this.IconImage = 'pages/control/widgets/homegenie/generic/images/door_closed.png';
             this.StatusText = "Locked";
@@ -51,7 +62,7 @@
         }
 
         this.Description = (module.Domain.substring(module.Domain.lastIndexOf('.') + 1)) + ' ' + module.Address;
-        
+
         //
         // render widget
         //

--- a/MigFiles/MIG/Interfaces/HomeAutomation/ZWave.cs
+++ b/MigFiles/MIG/Interfaces/HomeAutomation/ZWave.cs
@@ -995,9 +995,13 @@ namespace MIG.Interfaces.HomeAutomation
                 case EventParameter.AlarmGeneric:
                     path = ModuleParameters.MODPAR_SENSOR_ALARM_GENERIC;
                     // Translate generic alarm into specific Door Lock event values if node is an entry control type device
-                    if ((sender as ZWaveNode).GenericClass == (byte)GenericType.EntryControl)
+                    //at this level the sender is the controller so get the node from eventData
+                    if (eventData.Node.GenericClass == (byte)GenericType.EntryControl)
                     {
-                        value = ((DoorLock.Alarm)value).ToString();
+                        // do not convert to string since Alarms accept ONLY numbers a string would be outputed as NaN
+                        // for now let it as is.
+
+//                        value = ((DoorLock.Alarm)(byte)value).ToString();
                     }
                     break;
                 case EventParameter.AlarmDoorWindow:
@@ -1023,7 +1027,7 @@ namespace MIG.Interfaces.HomeAutomation
                     break;
                 case EventParameter.DoorLockStatus:
                     path = ModuleParameters.MODPAR_STATUS_DOORLOCK;
-                    value = ((DoorLock.Value)value).ToString();
+                    value = ((DoorLock.Value)(byte)value).ToString();
                     break;
                 case EventParameter.ManufacturerSpecific:
                     ManufacturerSpecificInfo mf = (ManufacturerSpecificInfo)value;

--- a/MigFiles/SupportLibraries/ZWaveLib/CommandClasses/DoorLock.cs
+++ b/MigFiles/SupportLibraries/ZWaveLib/CommandClasses/DoorLock.cs
@@ -71,16 +71,16 @@ namespace ZWaveLib.CommandClasses
         
         public static void Set(ZWaveNode node, Value value)
         {
-            byte bValue;
+            byte lockValue;
             if (value == DoorLock.Value.Secured)
-                bValue = 255;
+                lockValue = 255;
             else
-                bValue = 0;
+                lockValue = 0;
 
             node.SendRequest(new byte[] { 
                 (byte)CommandClass.DoorLock, 
                 (byte)Command.DoorLockSet,
-                (byte)value
+                (byte)lockValue
             });
         }
     }

--- a/MigFiles/SupportLibraries/ZWaveLib/CommandClasses/DoorLock.cs
+++ b/MigFiles/SupportLibraries/ZWaveLib/CommandClasses/DoorLock.cs
@@ -71,6 +71,12 @@ namespace ZWaveLib.CommandClasses
         
         public static void Set(ZWaveNode node, Value value)
         {
+            byte bValue;
+            if (value == DoorLock.Value.Secured)
+                bValue = 255;
+            else
+                bValue = 0;
+
             node.SendRequest(new byte[] { 
                 (byte)CommandClass.DoorLock, 
                 (byte)Command.DoorLockSet,


### PR DESCRIPTION
after the latest changes in DoorLock and Alarm area the widget is not
working as expected. Fixed the widget.

One item that still needs to be handled is that the Alarms - after
re-implemented don't send a notification to update the status of the
widget.

Example:
- Secure the door from widget
- unlock the door from the doorlock

the widget would still show that the door is locked.

I'm not sure the best way to handle this without causing other issues
and doing it in a generic way