### PR TITLE
Update fonts from googleapis to use SSL

### DIFF
--- a/BaseFiles/Common/html/js/api/homegenie.webapp.js
+++ b/BaseFiles/Common/html/js/api/homegenie.webapp.js
@@ -125,7 +125,7 @@ HG.WebApp.InitializePage = function ()
         //
         // add css google web fonts
         setTimeout(function(){
-            $('head').append('<link href="http://fonts.googleapis.com/css?family=Oxygen:400,700&subset=latin,latin-ext" rel="stylesheet" type="text/css">');
+            $('head').append('<link href="https://fonts.googleapis.com/css?family=Oxygen:400,700&subset=latin,latin-ext" rel="stylesheet" type="text/css">');
         }, 5000);
 
     }, 100);


### PR DESCRIPTION
This is a quick-fix to get rid of warnings of "insecure content" when using an SSL proxy. It also works fine when not using SSL. A more appropriate fix might be to pull these files in locally, but this does solve the issue.

Issue reference: https://github.com/genielabs/HomeGenie/issues/190