### PR TITLE
Add support for Z-Wave MULTI_CMD command class

### DIFF
--- a/MigFiles/SupportLibraries/ZWaveLib/CommandClasses/MultiCmd.cs
+++ b/MigFiles/SupportLibraries/ZWaveLib/CommandClasses/MultiCmd.cs
@@ -16,7 +16,7 @@
 */
 
 /*
-*     Author: https://github.com/snagytx
+*     Author: https://github.com/mdave
 *     Project Homepage: http://homegenie.it
 */
 using System;

--- a/MigFiles/SupportLibraries/ZWaveLib/CommandClasses/MultiCmd.cs
+++ b/MigFiles/SupportLibraries/ZWaveLib/CommandClasses/MultiCmd.cs
@@ -1,0 +1,91 @@
+﻿/*
+    This file is part of HomeGenie Project source code.
+
+    HomeGenie is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    HomeGenie is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with HomeGenie.  If not, see <http://www.gnu.org/licenses/>.  
+*/
+
+/*
+*     Author: https://github.com/snagytx
+*     Project Homepage: http://homegenie.it
+*/
+using System;
+using ZWaveLib.Values;
+
+namespace ZWaveLib.CommandClasses
+{
+    public class MultiCmd : ICommandClass
+    {
+        public CommandClass GetClassId()
+        {
+            return CommandClass.MultiCmd;
+        }
+
+        public ZWaveEvent GetEvent(ZWaveNode node, byte[] message)
+        {
+            byte i, offset = 3;
+
+            ZWaveEvent parent = null, child = null;
+
+            Utility.DebugLog(DebugMessageType.Information, String.Format("MultiCmd encapsulated message: {0}", Utility.ByteArrayToString(message)));
+
+            if (message[1] != (byte)1)
+            {
+                return parent;
+            }
+
+            // Loop over each message and process it in turn.
+            for (i = 0; i < message[2]; i++)
+            {
+                // Length and command classes of sub-command.
+                byte length   = message[offset];
+                byte cmdClass = message[offset+1];
+
+                // Copy message into new array.
+                var instanceMessage = new byte[length];
+                Array.Copy(message, offset+1, instanceMessage, 0, length);
+                Utility.DebugLog(DebugMessageType.Information, String.Format("Processing message chunk: {0}", Utility.ByteArrayToString(instanceMessage)));
+
+                // Grab command class from the factory. If we don't have one, print out a warning and continue.
+                var cc = CommandClassFactory.GetCommandClass(cmdClass);
+
+                if (cc == null)
+                {
+                    Utility.DebugLog(DebugMessageType.Information, String.Format("Can't find CommandClass handler for command class {0}", cmdClass));
+                    continue;
+                }
+
+                // Chain this event onto previously seen events.
+                ZWaveEvent tmp = cc.GetEvent(node, instanceMessage);
+                offset += (byte)(length+1);
+
+                if (tmp == null)
+                {
+                    continue;
+                }
+
+                if (parent == null)
+                {
+                    parent = child = tmp;
+                }
+                else
+                {
+                    child.NestedEvent = tmp;
+                    child = tmp;
+                }
+            }
+
+            return parent;
+        }
+    }
+}

--- a/MigFiles/SupportLibraries/ZWaveLib/Enums/CommandClass.cs
+++ b/MigFiles/SupportLibraries/ZWaveLib/Enums/CommandClass.cs
@@ -42,6 +42,8 @@ namespace ZWaveLib
         Association = 0x85,
         Version = 0x86,
         //
+        MultiCmd = 0x8F,
+        //
         Security = 0x98,
         //
         SensorAlarm = 0x9C,

--- a/MigFiles/SupportLibraries/ZWaveLib/ZWaveLib.csproj
+++ b/MigFiles/SupportLibraries/ZWaveLib/ZWaveLib.csproj
@@ -80,6 +80,7 @@
     <Compile Include="CommandClasses\UserCode.cs" />
     <Compile Include="CommandClasses\Crc16Encapsulated.cs" />
     <Compile Include="CommandClasses\ThermostatMode.cs" />
+    <Compile Include="CommandClasses\MultiCmd.cs" />
     <Compile Include="Utility\AesWork.cs" />
     <Compile Include="Utility\Utility.cs" />
   </ItemGroup>


### PR DESCRIPTION
This PR adds support for the MULTI_CMD command class to ZWaveLib using the same logic that can be found in other open-source Z-Wave projects (OpenHAB, Open-ZWave). Some battery operated sensors, such as one version of the Zipato multi-sensor triple motion/luminance/temperature sensor that I have, use this to chain multiple commands into one update message. This code extracts the messages and creates a `ZWaveEvent` chain along similar lines to the `MultiInstance` command class.

Some things to bear in mind are that I've never touched C# before today, pretty much! So whilst this works for me, perhaps there is something critical I missed. Very happy to modify things however you see fit.

Awesome work on this project by the way. Most things, including the BeWave keycode/RFID pad that is a pain to get working in most other HA projects, have worked straight out of the box for me. And it has been super easy to jump in and get this fixed up. Hoping to be able to contribute more in future!