### PR TITLE
Add entry to pepper1 database for Zipato RFID tag reader

### DIFF
--- a/BaseFiles/Common/Common.csproj
+++ b/BaseFiles/Common/Common.csproj
@@ -4915,6 +4915,9 @@
     <None Include="html\ui\widgets\capture.js">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="html\ext\zwave\pepper1db\0097_6131_4501.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="dummy.cs" />

--- a/BaseFiles/Common/html/ext/zwave/pepper1db/0097_6131_4501.json
+++ b/BaseFiles/Common/html/ext/zwave/pepper1db/0097_6131_4501.json
@@ -1,0 +1,329 @@
+﻿{
+  "?xml": {
+    "@version": "1.0",
+    "@encoding": "utf-8"
+  },
+  "ZWaveDevice": {
+    "@xmlns": "http://www.pepper1.net/zwavedb/xml-schemata/z-wave",
+    "@schemaVersion": "2",
+    "descriptorVersion": "1",
+    "deviceData": {
+      "manufacturerId": {
+        "@value": "0097"
+      },
+      "productType": {
+        "@value": "6131"
+      },
+      "productId": {
+        "@value": "4501"
+      },
+      "libType": {
+        "@value": "03"
+      },
+      "protoVersion": {
+        "@value": "02"
+      },
+      "protoSubVersion": {
+        "@value": "61"
+      },
+      "appVersion": {
+        "@value": "01"
+      },
+      "appSubVersion": {
+        "@value": "01"
+      },
+      "basicClass": {
+        "@value": "04"
+      },
+      "genericClass": {
+        "@value": "40"
+      },
+      "specificClass": {
+        "@value": "00"
+      },
+      "optional": {
+        "@value": "true"
+      },
+      "listening": {
+        "@value": "false"
+      },
+      "routing": {
+        "@value": "true"
+      },
+      "beamSensor": "0",
+      "rfFrequency": "EU",
+      "certId": "14324",
+      "certNumber": "ZC08-11080001"
+    },
+    "deviceDescription": {
+      "description": {
+        "lang": {
+          "@xml:lang": "en",
+          "#text": "RFID Tag Reader"
+        }
+      },
+      "wakeupNote": {
+        "lang": {
+          "@xml:lang": "en",
+          "#text": "Tap a button. The always awake mode can be activated by: CONFIGURATION_SET / Parameter: 0x05 / Size: 0x01 (can’t be different from 1) /\r\nValue: 0x03 (mode 3)"
+        }
+      },
+      "inclusionNote": {
+        "lang": {
+          "@xml:lang": "en",
+          "#text": "Press and hold the tamper for 1 seconds and release to start the inclusion/exclusion process."
+        }
+      },
+      "productName": "Tag Reader",
+      "brandName": "Tag Reader",
+      "productLine": "Security",
+      "productCode": "7",
+      "productVersion": "1.0",
+      "batteryType": "AA",
+      "batteryCount": "2"
+    },
+    "commandClasses": {
+      "commandClass": [
+        {
+          "@id": "0080"
+        },
+        {
+          "@id": "0020",
+          "@inNIF": "false"
+        },
+        {
+          "@id": "0063"
+        },
+        {
+          "@id": "0084"
+        },
+        {
+          "@id": "0085"
+        },
+        {
+          "@id": "0086"
+        },
+        {
+          "@id": "0070"
+        },
+        {
+          "@id": "0071",
+          "@version": "2"
+        },
+        {
+          "@id": "0072",
+          "@version": "2"
+        },
+        {
+          "@id": "0025"
+        }
+      ]
+    },
+    "assocGroups": {
+      "assocGroup": {
+        "@number": "1",
+        "@maxNodes": "5",
+        "description": {
+          "lang": {
+            "@xml:lang": "en",
+            "#text": "The Association Command Class is used to associate the TagReader to other devices. When a tag or code is\r\nread, the TagReader will send a notification to the Z‐Wave devices in its association group. It will also report\r\nthe state of the tamper alarm to the devices in this association group."
+          }
+        }
+      }
+    },
+    "configParams": {
+      "configParam": [
+        {
+          "@number": "1",
+          "@type": "range",
+          "@size": "1",
+          "@default": "00",
+          "name": {
+            "lang": {
+              "@xml:lang": "en",
+              "#text": "Set to default"
+            }
+          },
+          "description": {
+            "lang": {
+              "@xml:lang": "en",
+              "#text": "Set all configuration values to default values (factory settings).\r\nRead more in chapter Configuration Reset."
+            }
+          },
+          "value": {
+            "@from": "80",
+            "@to": "7f",
+            "description": {
+              "lang": {
+                "@xml:lang": "en",
+                "#text": "If 0xFF (-1) then set to default"
+              }
+            }
+          }
+        },
+        {
+          "@number": "2",
+          "@type": "constant",
+          "@size": "1",
+          "@default": "00",
+          "name": {
+            "lang": {
+              "@xml:lang": "en",
+              "#text": "Feedback time"
+            }
+          },
+          "description": {
+            "lang": {
+              "@xml:lang": "en",
+              "#text": "To configure the time the beep is automatically turned off in seconds."
+            }
+          },
+          "value": [
+            {
+              "@from": "00",
+              "@to": "00",
+              "description": {
+                "lang": {
+                  "@xml:lang": "en",
+                  "#text": "Disabled"
+                }
+              }
+            },
+            {
+              "@from": "ff",
+              "@to": "ff",
+              "description": {
+                "lang": {
+                  "@xml:lang": "en",
+                  "#text": "Endless"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "@number": "3",
+          "@type": "range",
+          "@size": "1",
+          "@default": "00",
+          "name": {
+            "lang": {
+              "@xml:lang": "en",
+              "#text": "Feedback timeout"
+            }
+          },
+          "description": {
+            "lang": {
+              "@xml:lang": "en",
+              "#text": "To configure the timeout to wait for a\r\nWAKEUP_NO_MORE_INFORMATION before the error beep is automatically sound. The error beep are fixed 8 beeps shortly after each other."
+            }
+          },
+          "value": {
+            "@from": "80",
+            "@to": "7f",
+            "description": {
+              "lang": {
+                "@xml:lang": "en",
+                "#text": "0x00 means disabled "
+              }
+            }
+          }
+        },
+        {
+          "@number": "4",
+          "@type": "range",
+          "@size": "1",
+          "@default": "02",
+          "name": {
+            "lang": {
+              "@xml:lang": "en",
+              "#text": "Feedback beeps per second"
+            }
+          },
+          "description": {
+            "lang": {
+              "@xml:lang": "en",
+              "#text": "To configure the number of beeps per second. Every beep is fixed about 10ms."
+            }
+          },
+          "value": {
+            "@from": "80",
+            "@to": "7f",
+            "@unit": "10ms",
+            "description": {
+              "lang": {
+                "@xml:lang": "en",
+                "#text": "Number of beeps per second"
+              }
+            }
+          }
+        },
+        {
+          "@number": "5",
+          "@type": "range",
+          "@size": "1",
+          "@default": "01",
+          "name": {
+            "lang": {
+              "@xml:lang": "en",
+              "#text": "The mode"
+            }
+          },
+          "description": {
+            "lang": {
+              "@xml:lang": "en",
+              "#text": "To configure the operating mode."
+            }
+          },
+          "value": [
+            {
+              "@from": "01",
+              "@to": "01",
+              "description": {
+                "lang": {
+                  "@xml:lang": "en",
+                  "#text": "Normal operating mode"
+                }
+              }
+            },
+            {
+              "@from": "03",
+              "@to": "03",
+              "description": {
+                "lang": {
+                  "@xml:lang": "en",
+                  "#text": "Z‐Wave chip is always on to request e.g. version or manufacturer id."
+                }
+              }
+            },
+            {
+              "@from": "02",
+              "@to": "02",
+              "description": {
+                "lang": {
+                  "@xml:lang": "en",
+                  "#text": "If any mode other then 3, that value will be reported after a get but\r\nwill be handled in SW as mode 1."
+                }
+              }
+            },
+            {
+              "@from": "04",
+              "@to": "7f",
+              "description": {
+                "lang": {
+                  "@xml:lang": "en",
+                  "#text": "If any mode other then 3, that value will be reported after a get but\r\nwill be handled in SW as mode 1."
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "resourceLinks": {
+      "deviceImage": {
+        "@url": "http://www.pepper1.net/zwavedb/uploads/resources/68c37a3151f6ae957c98c684e3544e8f9e4d0ea8.jpg"
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR adds support to the pepper1 database for the Zipato RFID tag reader, with ID 0097:6131:4501. Unfortunately the lineage of this reader is a bit convoluted. It's identical to the BeNext tag reader, but the manufacturer ID 0x0097 belongs to Schlage, who don't seem to ship this any more (see http://www.fhemwiki.de/wiki/Z-Wave-ZIP_WT-RFID_Keypad for the only article I've found on this). I've therefore duplicated the BeNext entry (http://www.pepper1.net/zwavedb/device/302) with the appropriate ID.