### PR TITLE
Overload for MqttClientHelper Publish

### DIFF
--- a/HomeGenie/Automation/Scripting/MqttClientHelper.cs
+++ b/HomeGenie/Automation/Scripting/MqttClientHelper.cs
@@ -129,6 +129,20 @@ namespace HomeGenie.Automation.Scripting
             }
             return this;
         }
+        
+        /// <summary>
+        /// Publish a message to the specified topic.
+        /// </summary>
+        /// <param name="topic">Topic name.</param>
+        /// <param name="message">Message text as byte array.</param>
+        public MqttClientHelper Publish(string topic, byte[] message)
+        {
+        	lock (mqttSyncLock)
+        	{
+        		mqttClient.PublishMessage(topic, message);
+        	}
+        	return this;
+        }
 
         /// <summary>
         /// Use provided credentials when connecting.


### PR DESCRIPTION
Overload for MqttClientHelper Publish accepting string, byte[]. This overload works well with the MySensor MQTT gateway.

See http://www.homegenie.it/forum/index.php?topic=1038.0 for more info.