### PR TITLE
Spelling error fix - ZWave's "Operation Failed"

### DIFF
--- a/BaseFiles/Common/html/pages/configure/interfaces/configlet/zwave.html
+++ b/BaseFiles/Common/html/pages/configure/interfaces/configlet/zwave.html
@@ -285,7 +285,7 @@ HG.WebApp.SystemSettings.Interfaces['HomeAutomation.ZWave'] = {
             }
             else {
                 nodeid.html('<span style="color:red">timed out</span>');
-                message.html('operation falied.');
+                message.html('operation failed.');
             }
             _this.NodeOperationPopup.find('[data-ui-field=close_button]').removeClass('ui-disabled');
         });


### PR DESCRIPTION
Fixes minor spelling error for Z-Wave's "Operation Failed"