### PR TITLE
Fix issue with international characters during zip archiving.

### DIFF
--- a/HomeGenie/Service/Utility.cs
+++ b/HomeGenie/Service/Utility.cs
@@ -441,6 +441,7 @@ namespace HomeGenie.Service
 
         internal static void AddFileToZip(string zipFilename, string fileToAdd, string storeAsName = null)
         {
+            ZipConstants.DefaultCodePage = System.Text.Encoding.UTF8.CodePage;
             if (!File.Exists(zipFilename))
             {
                 FileStream zfs = File.Create(zipFilename);


### PR DESCRIPTION
Hi, Gene.
After upgrading to the latest release of HG r510 I was unable to backup my settings. There was following error in output:

```
2016-01-06 00:45:30.9830 Info WebServiceGateway	46.188.70.238	HTTP	GET	200 /api/HomeAutomation.HomeGenie/Config/System.Configure/System.ConfigurationBackup [OPEN]
2016-01-06 00:45:31.2523 Info HomeGenie.System	0	HomeGenie System	HomeGenie.Status	SAVING DATA
  at ICSharpCode.SharpZipLib.Zip.ZipFile.RunUpdates () [0x00000] in <filename unknown>:0 System.NotSupportedException: CodePage 866 not supported
  at System.Text.Encoding.GetEncoding (Int32 codepage) [0x00000] in <filename unknown>:0 
  at ICSharpCode.SharpZipLib.Zip.ZipConstants.ConvertToArray (System.String str) [0x00000] in <filename unknown>:0 
  at ICSharpCode.SharpZipLib.Zip.ZipConstants.ConvertToArray (Int32 flags, System.String str) [0x00000] in <filename unknown>:0 
  at ICSharpCode.SharpZipLib.Zip.ZipFile.WriteLocalEntryHeader (ICSharpCode.SharpZipLib.Zip.ZipUpdate update) [0x00000] in <filename unknown>:0 
  at ICSharpCode.SharpZipLib.Zip.ZipFile.AddEntry (ICSharpCode.SharpZipLib.Zip.ZipFile workFile, ICSharpCode.SharpZipLib.Zip.ZipUpdate update) [0x00000] in <filename unknown>:0 
```

I think cyrillic characters in modules' names raised the error. Using UTF8 as the default encoding solved the problem.