### PR TITLE
Added support for optionally specifying Parity and Stop bits with the…

### DIFF
--- a/HomeGenie/Automation/Scripting/SerialPortHelper.cs
+++ b/HomeGenie/Automation/Scripting/SerialPortHelper.cs
@@ -24,6 +24,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.IO.Ports;
 
 using SerialPortLib;
 
@@ -72,11 +73,13 @@ namespace HomeGenie.Automation.Scripting
         /// Connect the serial port at the specified speed.
         /// </summary>
         /// <param name="baudRate">Baud rate.</param>
-        public bool Connect(int baudRate)
+        /// <param name="stopBits">Stop Bits.</param>
+        /// <param name="parity">Parity.</param>
+        /// 
+        public bool Connect(int baudRate, StopBits stopBits = StopBits.One, Parity parity = Parity.None)
         {
             serialPort.MessageReceived += SerialPort_MessageReceived;
             serialPort.ConnectionStatusChanged += SerialPort_ConnectionStatusChanged;
-            //
             serialPort.SetPort(portName, baudRate);
             return serialPort.Connect();
         }

--- a/HomeGenie/HomeGenie.csproj
+++ b/HomeGenie/HomeGenie.csproj
@@ -104,6 +104,9 @@
       <HintPath>..\Externals\NCrontab\NCrontab.dll</HintPath>
       <Private>False</Private>
     </Reference>
+    <Reference Include="SerialPortLib">
+      <HintPath>..\..\serialport-lib-dotnet2\SerialPortLib\bin\Debug\SerialPortLib.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.ServiceProcess" />
@@ -161,9 +164,6 @@
     </Reference>
     <Reference Include="MIG">
       <HintPath>..\Externals\g-labs\MIG.dll</HintPath>
-    </Reference>
-    <Reference Include="SerialPortLib">
-      <HintPath>..\Externals\g-labs\SerialPortLib.dll</HintPath>
     </Reference>
     <Reference Include="ICSharpCode.SharpZipLib">
       <HintPath>..\Externals\SharpZipLib\ICSharpCode.SharpZipLib.dll</HintPath>
@@ -323,7 +323,5 @@
       </Properties>
     </MonoDevelop>
   </ProjectExtensions>
-  <ItemGroup>
-    <Folder Include="Automation\Engines\" />
-  </ItemGroup>
+  <ItemGroup />
 </Project>


### PR DESCRIPTION
… serial port helper

I have added optional parameters for specifying the Stop Bits and Partity. This change is non breaking and existing scripts will still work due to them being optional and defaulting to None and 1.