### PR TITLE
Module add dialog

### DIFF
--- a/BaseFiles/Common/html/locales/de.json
+++ b/BaseFiles/Common/html/locales/de.json
@@ -69,7 +69,7 @@
         "Abbrechen",
     "configure_group_deleteconfirm":
         "Löschen",
-    "configure_module_newmoduleadd":
+    "configure_group_addmodule":
         "Neues Modul hinzufügen",
     "configure_module_newmodulecancel":
         "Abbrechen",

--- a/BaseFiles/Common/html/locales/en.json
+++ b/BaseFiles/Common/html/locales/en.json
@@ -69,8 +69,10 @@
          "Cancel",
     "configure_group_deleteconfirm":
          "Delete",
-    "configure_module_newmoduleadd":
+    "configure_group_addmodule":
          "Add New Module",
+	 "configure_automation_group_modulechoose_desc":
+			"Tap a module to add it.",
     "configure_module_newmodulecancel":
          "Cancel",
     "configure_module_newmoduleconfirm":

--- a/BaseFiles/Common/html/locales/es.json
+++ b/BaseFiles/Common/html/locales/es.json
@@ -69,7 +69,7 @@
         "Cancelar",
     "configure_group_deleteconfirm":
         "Eliminar",
-    "configure_module_newmoduleadd":
+    "configure_group_addmodule":
         "Añadir nuevo módulo",
     "configure_module_newmodulecancel":
         "Cancelar",

--- a/BaseFiles/Common/html/locales/fr.json
+++ b/BaseFiles/Common/html/locales/fr.json
@@ -69,7 +69,7 @@
         "Annuler",
     "configure_group_deleteconfirm":
         "Supprimer",
-    "configure_module_newmoduleadd":
+    "configure_group_addmodule":
         "Ajouter un Module",
     "configure_module_newmodulecancel":
         "Annuler",

--- a/BaseFiles/Common/html/locales/it.json
+++ b/BaseFiles/Common/html/locales/it.json
@@ -69,7 +69,7 @@
          "Annulla",
     "configure_group_deleteconfirm":
          "Rimuovi",
-    "configure_module_newmoduleadd":
+    "configure_group_addmodule":
          "Agg. Nuovo Modulo",
     "configure_module_newmodulecancel":
          "Annulla",

--- a/BaseFiles/Common/html/locales/nl.json
+++ b/BaseFiles/Common/html/locales/nl.json
@@ -69,7 +69,7 @@
         "Afbreken",
     "configure_group_deleteconfirm":
         "Verwijderen",
-    "configure_module_newmoduleadd":
+    "configure_group_addmodule":
         "Nieuwe module toevoegen",
     "configure_module_newmodulecancel":
         "Afbreken",

--- a/BaseFiles/Common/html/locales/ru.json
+++ b/BaseFiles/Common/html/locales/ru.json
@@ -69,7 +69,7 @@
         "Отмена",
     "configure_group_deleteconfirm": 
         "Удалить",
-    "configure_module_newmoduleadd": 
+    "configure_group_addmodule": 
         "Добавить новый модуль",
     "configure_module_newmodulecancel": 
         "Отмена",

--- a/BaseFiles/Common/html/locales/sv.json
+++ b/BaseFiles/Common/html/locales/sv.json
@@ -69,8 +69,10 @@
         "Avbryt",
     "configure_group_deleteconfirm": 
         "Ta Bort",
-    "configure_module_newmoduleadd": 
+    "configure_group_addmodule": 
         "Lägg Till Ny Modul",
+	 "configure_automation_group_modulechoose_desc":
+			"Klicka på en modul för att lägga till den.",
     "configure_module_newmodulecancel": 
         "Avbryt",
     "configure_module_newmoduleconfirm": 

--- a/BaseFiles/Common/html/pages/configure/groups/_groupmodules.js
+++ b/BaseFiles/Common/html/pages/configure/groups/_groupmodules.js
@@ -97,7 +97,7 @@
                                 cursect = module.Domain;
                             }
                             $('#automation_group_module_list').append($('<li/>', {
-                                'data-icon': 'minus',
+                                'data-icon': 'plus',
                                 'data-context-domain': module.Domain,
                                 'data-context-address': module.Address
                             })
@@ -108,6 +108,7 @@
                         }
                     }
                 }
+                $('#automation_group_module_list').listview('refresh');
             };
 
             $$.AddGroupModule = function (group, domain, address, callback) {

--- a/BaseFiles/Common/html/pages/configure/groups/_groupmodules.js
+++ b/BaseFiles/Common/html/pages/configure/groups/_groupmodules.js
@@ -9,23 +9,6 @@
     $$.InitializePage = function () {
         var page = $$.getContainer();
         page.on('pageinit', function (e) {
-            $$.field('#module_add_button', true).on('click', function (event) {
-                var selectedopt = $$.field('#automation_group_moduleadd', true).find(":selected");
-                var domain = selectedopt.attr('data-context-domain');
-                var address = selectedopt.attr('data-context-value');
-                $$.AddGroupModule($$.CurrentGroup, domain, address, function () {
-                    var list = $$.field('#page_configure_groupmodules_list', true).find('ul');
-                    var item = list.find('li').last();
-                    list.parent().animate({scrollTop: item.position().top});
-                    /*
-                     var availHeight = $(window).height()-item.height()-50;
-                     $.mobile.silentScroll(item.position().top-availHeight);
-                     $$.EditCurrentModule(item);
-                     $.mobile.loading('show');
-                     setTimeout("$('#automation_group_module_edit').popup('open');$.mobile.loading('hide');", 1000);
-                     */
-                });
-            });
             $$.field('#group_delete_button', true).on('click', function (event) {
                 $$.DeleteGroup($$.CurrentGroup);
             });
@@ -61,12 +44,97 @@
                     $$.field('#btn_configure_group_editseparatoradd', true).show();
                 }
             });
+
             $$.field('#automation_group_modulechoose', true).on('popupbeforeposition', function (event) {
-                var moduleAdd = $('#automation_group_moduleadd');
-                moduleAdd.empty();
-                moduleAdd.append($$.GetModulesListViewItems($$.CurrentGroup));
-                moduleAdd.selectmenu('refresh');
+                $$.GetModulesListViewItems($$.CurrentGroup);
             });
+
+            $('#automation_group_module_list').on('click', 'li', function () {
+                $.mobile.loading('show');
+                //
+                var domain = $(this).attr('data-context-domain');
+                var address = $(this).attr('data-context-address');
+                $$.AddGroupModule($$.CurrentGroup, domain, address, function () {
+                    var list = $$.field('#page_configure_groupmodules_list', true).find('ul');
+                    var item = list.find('li').last();
+                    list.parent().animate({ scrollTop: item.position().top });
+
+                    $$.GetModulesListViewItems($$.CurrentGroup);
+                    $.mobile.loading('hide');
+                });
+            });
+
+            $$.GetModulesListViewItems = function (groupname) {
+                var groupmodules = HG.Configure.Groups.GetGroupModules(groupname);
+                $('#automation_group_module_list').empty();
+                var cursect = '';
+                if (HG.WebApp.Data.Modules && HG.WebApp.Data.Modules.length) {
+                    for (m = 0; m < HG.WebApp.Data.Modules.length; m++) {
+                        var module = HG.WebApp.Data.Modules[m];
+                        var haselement = $.grep(groupmodules.Modules, function (value) {
+                            return (value.Domain == module.Domain && value.Address == module.Address);
+                        });
+                        // module it's not present in current group
+                        if (haselement.length == 0) {
+                            var propwidget = HG.WebApp.Utility.GetModulePropertyByName(module, "Widget.DisplayModule");
+                            var vmparentid = HG.WebApp.Utility.GetModulePropertyByName(module, "VirtualModule.ParentId");
+                            var widget = (propwidget != null && propwidget.Value != null) ? propwidget.Value : '';
+                            var vid = (vmparentid != null && vmparentid.Value != null) ? vmparentid.Value : '';
+                            // check if no explicit witdget is specified and it's not a virtual module or program
+                            if (module.Domain == 'HomeAutomation.HomeGenie.Automation') {
+                                var pid = (vid != '' && vid != module.Address) ? vid : module.Address;
+                                var cp = HG.WebApp.Utility.GetProgramByAddress(pid);
+                                if (cp != null) {
+                                    if (!cp.IsEnabled)
+                                        continue;
+                                    else if (cp.Type.toLowerCase() != 'wizard' && widget == '')
+                                        continue;
+                                }
+                            }
+
+                            if (cursect != module.Domain) {
+                                $('#automation_group_module_list').append($('<li/>', { 'data-role': 'list-divider' }).append(module.Domain));
+                                cursect = module.Domain;
+                            }
+                            $('#automation_group_module_list').append($('<li/>', {
+                                'data-icon': 'minus',
+                                'data-context-domain': module.Domain,
+                                'data-context-address': module.Address
+                            })
+                                .append($('<a/>',
+                                    {
+                                        'text': module.Address + ' ' + (module.Name != '' ? module.Name : (module.Description != '' ? module.Description : module.DeviceType))
+                                    })));
+                        }
+                    }
+                }
+            };
+
+            $$.AddGroupModule = function (group, domain, address, callback) {
+                var alreadyexists = false;
+                var moduleindex = -1;
+                for (i = 0; i < HG.WebApp.Data.Groups.length; i++) {
+                    if (HG.WebApp.Data.Groups[i].Name == group) {
+                        for (c = 0; c < HG.WebApp.Data.Groups[i].Modules.length; c++) {
+                            if (domain == HG.WebApp.Data.Groups[i].Modules[c].Domain && address == HG.WebApp.Data.Groups[i].Modules[c].Address) {
+                                alreadyexists = true;
+                                break;
+                            }
+                        }
+                        if (!alreadyexists) {
+                            HG.WebApp.Data.Groups[i].Modules.push({ 'Address': address, 'Domain': domain });
+                            moduleindex = HG.WebApp.Data.Groups[i].length - 1;
+                        }
+                        //
+                        break;
+                    }
+                }
+                //
+                HG.WebApp.GroupsList.SaveGroups(function () {
+                    callback();
+                });
+            };
+
             $$.field('#automation_group_module_propdelete', true).on('click', function () {
                 if ($$.CurrentModuleProperty != null) {
                     $$.ModulePropertyDelete($$.CurrentModuleProperty.find('input[type=text]').first().val());
@@ -305,72 +373,6 @@
             $(this).closest('div').parent().parent().parent().css('background', $(this).attr('originalbackground'));
             setTimeout("$('#automation_group_module_propdelete').addClass('ui-disabled')", 250);
             //        setTimeout("$('#automation_group_module_propsave').addClass('ui-disabled')", 250);
-        });
-    };
-
-    $$.GetModulesListViewItems = function (groupname) {
-        var groupmodules = HG.Configure.Groups.GetGroupModules(groupname);
-        var htmlopt = '';
-        var cursect = '';
-        if (HG.WebApp.Data.Modules && HG.WebApp.Data.Modules.length) {
-            for (m = 0; m < HG.WebApp.Data.Modules.length; m++) {
-                var module = HG.WebApp.Data.Modules[m];
-                var haselement = $.grep(groupmodules.Modules, function (value) {
-                    return (value.Domain == module.Domain && value.Address == module.Address);
-                });
-                // module it's not present in current group
-                if (haselement.length == 0) {
-                    var propwidget = HG.WebApp.Utility.GetModulePropertyByName(module, "Widget.DisplayModule");
-                    var vmparentid = HG.WebApp.Utility.GetModulePropertyByName(module, "VirtualModule.ParentId");
-                    var widget = (propwidget != null && propwidget.Value != null) ? propwidget.Value : '';
-                    var vid = (vmparentid != null && vmparentid.Value != null) ? vmparentid.Value : '';
-                    // check if no explicit witdget is specified and it's not a virtual module or program
-                    if (module.Domain == 'HomeAutomation.HomeGenie.Automation') {
-                        var pid = (vid != '' && vid != module.Address) ? vid : module.Address;
-                        var cp = HG.WebApp.Utility.GetProgramByAddress(pid);
-                        if (cp != null) {
-                            if (!cp.IsEnabled)
-                                continue;
-                            else if (cp.Type.toLowerCase() != 'wizard' && widget == '')
-                                continue;
-                        }
-                    }
-                    //
-                    if (cursect != module.Domain) {
-                        cursect = module.Domain;
-                        htmlopt += '<optgroup label="' + cursect + '"></optgroup>';
-                    }
-                    var displayname = (module.Name != '' ? module.Name : (module.Description != '' ? module.Description : module.DeviceType));
-                    displayname += ' (' + module.Address + ')';
-                    htmlopt += '<option data-context-domain="' + module.Domain + '" data-context-value="' + module.Address + '">' + displayname + '</option>';
-                }
-            }
-        }
-        return htmlopt;
-    };
-
-    $$.AddGroupModule = function (group, domain, address, callback) {
-        var alreadyexists = false;
-        var moduleindex = -1;
-        for (i = 0; i < HG.WebApp.Data.Groups.length; i++) {
-            if (HG.WebApp.Data.Groups[i].Name == group) {
-                for (c = 0; c < HG.WebApp.Data.Groups[i].Modules.length; c++) {
-                    if (domain == HG.WebApp.Data.Groups[i].Modules[c].Domain && address == HG.WebApp.Data.Groups[i].Modules[c].Address) {
-                        alreadyexists = true;
-                        break;
-                    }
-                }
-                if (!alreadyexists) {
-                    HG.WebApp.Data.Groups[i].Modules.push({'Address': address, 'Domain': domain});
-                    moduleindex = HG.WebApp.Data.Groups[i].length - 1;
-                }
-                //
-                break;
-            }
-        }
-        //
-        HG.WebApp.GroupsList.SaveGroups(function () {
-            callback();
         });
     };
 

--- a/BaseFiles/Common/html/pages/configure/groups/listmodules.html
+++ b/BaseFiles/Common/html/pages/configure/groups/listmodules.html
@@ -1,4 +1,4 @@
-<!-- Manage Grpup Modules -->
+<!-- Manage Group Modules -->
 <div data-role="page" id="page_configure_groupmodules" data-upload-dropzone="wallpaper">
 
     {include pages/header.html}
@@ -64,26 +64,18 @@
         </div>
     </div>
 
-    <div id="automation_group_modulechoose" class="ui-corner-all hg-popup-a" data-role="popup" data-overlay-theme="b" data-position-to="window">
+    <div id="automation_group_modulechoose" class="ui-corner-all hg-popup-a" data-role="popup" data-position-to="window" data-transition="pop" data-overlay-theme="b">
+        <a href="#" data-rel="back" class="ui-btn ui-corner-all ui-shadow ui-icon-delete ui-btn-icon-notext ui-btn-right">Close</a>
         <div data-role="header" class="ui-corner-top">
             <h1 data-locale-id="configure_module_newmoduleadd">Add New Module</h1>
+		</div>
+        <div class="ui-content ui-corner-bottom ui-content" style="height:280px;max-height:280px;overflow-y:scroll;overflow-x:hidden;">
+		        <ul id="automation_group_module_list" data-role="listview"></ul>
         </div>
-        <div class="ui-content ui-corner-bottom">
-            <select id="automation_group_moduleadd"></select>
-        </div>
-        <div class="ui-grid-a ui-footer ui-bar-inherit">
-            <div class="ui-grid-a">
-                <div class="ui-block-a" align="left">
-                    <a href="#" class="ui-btn ui-shadow ui-corner-all ui-btn-icon-left ui-icon-back" data-locale-id="configure_module_newmodulecancel" data-rel="back">Cancel</a>
-                </div>
-                <div class="ui-block-b" align="right">
-                    <a id="module_add_button" href="#" class="ui-btn ui-shadow ui-corner-all ui-btn-icon-right ui-icon-plus" data-locale-id="configure_module_newmoduleconfirm" data-rel="back">Add</a>
-                </div>
-            </div>
+        <div data-role="footer" data-tap-toggle="false" style="height:54px">
+		        <p align="center">Tap a module to add it.</p>
         </div>
     </div>
-
-
 
     <div id="automation_group_separator_edit" class="ui-corner-all hg-popup-a" data-role="popup" data-overlay-theme="b" data-position-to="window">
         <a href="#" data-rel="back" class="ui-btn ui-corner-all ui-shadow ui-icon-delete ui-btn-icon-notext ui-btn-right">Close</a>

--- a/BaseFiles/Common/html/pages/configure/groups/listmodules.html
+++ b/BaseFiles/Common/html/pages/configure/groups/listmodules.html
@@ -67,13 +67,13 @@
     <div id="automation_group_modulechoose" class="ui-corner-all hg-popup-a" data-role="popup" data-position-to="window" data-transition="pop" data-overlay-theme="b">
         <a href="#" data-rel="back" class="ui-btn ui-corner-all ui-shadow ui-icon-delete ui-btn-icon-notext ui-btn-right">Close</a>
         <div data-role="header" class="ui-corner-top">
-            <h1 data-locale-id="configure_module_newmoduleadd">Add New Module</h1>
+            <h1 data-locale-id="configure_group_addmodule">Add New Module</h1>
 		</div>
         <div class="ui-content ui-corner-bottom ui-content" style="height:280px;max-height:280px;overflow-y:scroll;overflow-x:hidden;">
-		        <ul id="automation_group_module_list" data-role="listview"></ul>
+		    <ul id="automation_group_module_list" data-role="listview"></ul>
         </div>
         <div data-role="footer" data-tap-toggle="false" style="height:54px">
-		        <p align="center">Tap a module to add it.</p>
+		    <p align="center" data-locale-id="configure_automation_group_modulechoose_desc">Tap a module to add it.</p>
         </div>
     </div>
 


### PR DESCRIPTION
Change the behavior/look of the add module dialog in groups. It now looks and works similar to the Modules cleanup dialog in Maintenance.
This makes it possible to add multiple modules to a group without the dialog closing.