### PR TITLE
Update homegenie.webapp.utility.js for displaying Temp with no decimal placed on Dashboard

### DIFF
--- a/BaseFiles/Common/html/js/app/homegenie.webapp.utility.js
+++ b/BaseFiles/Common/html/js/app/homegenie.webapp.utility.js
@@ -252,7 +252,12 @@ HG.WebApp.Utility = HG.WebApp.Utility || new function(){ var $$ = this;
         // old line
         // return (temp * 1).toFixed(2);
         // new line - to round up to no decimal places
-        return (temp * 1).toFixed(0);        
+        //  when displaying temperature as 'F'
+        if (temperatureUnit == 'F') {
+            return (temp * 1).toFixed(0);
+        } else {
+            return (temp * 1).toFixed(2);
+        }
     };
 
     $$.FormatTemperature = function (temp) {
@@ -264,14 +269,12 @@ HG.WebApp.Utility = HG.WebApp.Utility || new function(){ var $$ = this;
             // old line
             // displayvalue = (temp * 1).toFixed(1) + '&deg;'; //'&#8457;';
             // new line - to round up to no decimal places
+            //  when displaying temperature as 'F'
             displayvalue = (temp * 1).toFixed(0) + '&deg;';
         } else {
             // display as Celsius
             temp = Math.round(temp * 10) / 10;
-            // old line
-            // displayvalue = (temp * 1).toFixed(1) + '&deg;'; //'&#8451;';
-            // new line - to round up to no decimal places
-            displayvalue = (temp * 1).toFixed(0) + '&deg;';
+            displayvalue = (temp * 1).toFixed(1) + '&deg;'; //'&#8451;';
         }
         return displayvalue;
     };

--- a/BaseFiles/Common/html/js/app/homegenie.webapp.utility.js
+++ b/BaseFiles/Common/html/js/app/homegenie.webapp.utility.js
@@ -249,7 +249,10 @@ HG.WebApp.Utility = HG.WebApp.Utility || new function(){ var $$ = this;
             // display as Celsius
             temp = Math.round(temp * 10) / 10;
         }
-        return (temp * 1).toFixed(2);
+        // old line
+        // return (temp * 1).toFixed(2);
+        // new line - to round up to no decimal places
+        return (temp * 1).toFixed(0);        
     };
 
     $$.FormatTemperature = function (temp) {
@@ -258,11 +261,17 @@ HG.WebApp.Utility = HG.WebApp.Utility || new function(){ var $$ = this;
         if (temperatureUnit != 'C' && (temperatureUnit == 'F' || HG.WebApp.Locales.GetDateEndianType() == 'M')) {
             // display as Fahrenheit
             temp = Math.round((temp * 1.8 + 32) * 10) / 10;
-            displayvalue = (temp * 1).toFixed(1) + '&deg;'; //'&#8457;';
+            // old line
+            // displayvalue = (temp * 1).toFixed(1) + '&deg;'; //'&#8457;';
+            // new line - to round up to no decimal places
+            displayvalue = (temp * 1).toFixed(0) + '&deg;';
         } else {
             // display as Celsius
             temp = Math.round(temp * 10) / 10;
-            displayvalue = (temp * 1).toFixed(1) + '&deg;'; //'&#8451;';
+            // old line
+            // displayvalue = (temp * 1).toFixed(1) + '&deg;'; //'&#8451;';
+            // new line - to round up to no decimal places
+            displayvalue = (temp * 1).toFixed(0) + '&deg;';
         }
         return displayvalue;
     };


### PR DESCRIPTION
The temperature that is displayed in the Groups drop down (i.e. Dashboard) and in the upper right corner of the Dashboard if it contains the Weather Widget with a decimal place and one significant digit.

I made some changes to the Weather Widget to round the temperature up on that (along with the Fahrenheit display changes in another pull request) and I was able to find that making these changes as noted will round the temp display on the main Dashboard and Group drop down.  Not sure if this would be better as an option or just allow the no decimal place code to be the default but wanted to share what I found.

Thanks