### PR TITLE
Fix multiple instance of a program running .net core

### DIFF
--- a/src/HomeGenie/Automation/Engines/ProgramEngineBase.cs
+++ b/src/HomeGenie/Automation/Engines/ProgramEngineBase.cs
@@ -86,7 +86,14 @@ namespace HomeGenie.Automation.Engines
                 {
                     RoutedEventAck.Set();
                     if (!_startupThread.Join(1000))
+                    {
+#if NETCOREAPP
+                        // _programThread.Abort(); => System.PlatformNotSupportedException: Thread abort is not supported on this platform.
+                        _startupThread.Interrupt();
+#else
                         _startupThread.Abort();
+#endif
+                    }
                 }
                 catch
                 {

--- a/src/HomeGenie/Automation/Engines/ProgramEngineBase.cs
+++ b/src/HomeGenie/Automation/Engines/ProgramEngineBase.cs
@@ -132,7 +132,8 @@ namespace HomeGenie.Automation.Engines
                     _programThread = null;
                     ProgramBlock.IsRunning = false;
                     if (result != null && result.Exception != null &&
-                        result.Exception.GetType() != typeof(TargetException))
+                        result.Exception.GetType() != typeof(TargetException) &&
+                        result.Exception.GetType() != typeof(ThreadInterruptedException))
                     {
                         // runtime error occurred, script is being disabled
                         // so user can notice and fix it
@@ -148,6 +149,19 @@ namespace HomeGenie.Automation.Engines
                         ProgramBlock.IsEnabled ? "Idle" : "Stopped");
                 }
                 catch (ThreadAbortException)
+                {
+                    _programThread = null;
+                    ProgramBlock.IsRunning = false;
+                    if (HomeGenie.ProgramManager != null)
+                    {
+                        HomeGenie.ProgramManager.RaiseProgramModuleEvent(
+                            ProgramBlock,
+                            Properties.ProgramStatus,
+                            "Interrupted"
+                        );
+                    }
+                }
+                catch (ThreadInterruptedException)
                 {
                     _programThread = null;
                     ProgramBlock.IsRunning = false;
@@ -209,7 +223,14 @@ namespace HomeGenie.Automation.Engines
             try
             {
                 if (!_programThread.Join(1000))
+                {
+#if NETCOREAPP
+                    // _programThread.Abort(); => System.PlatformNotSupportedException: Thread abort is not supported on this platform.
+                    _programThread.Interrupt();
+#else
                     _programThread.Abort();
+#endif
+                }
             }
             catch
             {
@@ -326,7 +347,7 @@ namespace HomeGenie.Automation.Engines
                 catch (Exception ex)
                 {
                     // a runtime error occured
-                    if (ex.GetType() == typeof(TargetException) || ex is ThreadAbortException)
+                    if (ex.GetType() == typeof(TargetException) || ex is ThreadAbortException || ex is ThreadInterruptedException)
                         return isConditionSatisfied && ProgramBlock.IsEnabled;
                     List<ProgramError> error = new List<ProgramError>() {GetFormattedError(ex, true)};
                     ProgramBlock.ScriptErrors = JsonConvert.SerializeObject(error);

--- a/src/HomeGenie/Automation/Scheduler/SchedulerScriptingEngine.cs
+++ b/src/HomeGenie/Automation/Scheduler/SchedulerScriptingEngine.cs
@@ -159,6 +159,13 @@ namespace HomeGenie.Automation.Scheduler
                     homegenie.RaiseEvent(this, Domains.HomeAutomation_HomeGenie, SourceModule.Scheduler, eventItem.Name,
                         Properties.SchedulerScriptStatus, eventItem.Name + ":Interrupted");
                 }
+                catch (ThreadInterruptedException)
+                {
+                    programThread = null;
+                    isRunning = false;
+                    homegenie.RaiseEvent(this, Domains.HomeAutomation_HomeGenie, SourceModule.Scheduler, eventItem.Name,
+                        Properties.SchedulerScriptStatus, eventItem.Name + ":Interrupted");
+                }
                 homegenie.RaiseEvent(this, Domains.HomeAutomation_HomeGenie, SourceModule.Scheduler, eventItem.Name,
                     Properties.SchedulerScriptStatus, eventItem.Name + ":End");
             });

--- a/src/HomeGenie/Automation/Scheduler/SchedulerScriptingEngine.cs
+++ b/src/HomeGenie/Automation/Scheduler/SchedulerScriptingEngine.cs
@@ -147,10 +147,14 @@ namespace HomeGenie.Automation.Scheduler
                     }
                     programThread = null;
                     isRunning = false;
-                    if (result != null && result.Exception != null && result.Exception.GetType() != typeof(TargetException))
+                    if (result != null && result.Exception != null &&
+                        result.Exception.GetType() != typeof(TargetException) &&
+                        result.Exception.GetType() != typeof(ThreadInterruptedException))
+                    {
                         homegenie.RaiseEvent(this, Domains.HomeAutomation_HomeGenie, SourceModule.Scheduler,
                             eventItem.Name, Properties.SchedulerScriptStatus,
                             eventItem.Name + ":Error (" + result.Exception.Message.Replace('\n', ' ').Replace('\r', ' ') + ")");
+                    }
                 }
                 catch (ThreadAbortException)
                 {
@@ -188,7 +192,14 @@ namespace HomeGenie.Automation.Scheduler
                 try
                 {
                     if (!programThread.Join(1000))
+                    {
+#if NETCOREAPP
+                        // _programThread.Abort(); => System.PlatformNotSupportedException: Thread abort is not supported on this platform.
+                        programThread.Interrupt();
+#else
                         programThread.Abort();
+#endif
+                    }
                 }
                 catch
                 {


### PR DESCRIPTION
Hello,

I found that .NET core does not support Thread.Abort(), that was used to stop a program before compilation (CSharpEngine).

Resulting in multiple instance of same program continue to run on different thread.

After some extended tests with this simple program :

```charp
// CSharp Automation Program Plugin
// Example for using Helper Classes:
// Modules.WithName("Light 1").On();
var rand = new Random();
string unique_id = rand.Next(1024).ToString();

while (Program.IsRunning) {
  Pause(15);
  Program.Notify("test_multiple", unique_id);
}
```

Compiled multiple times gave me lots of "test_multiple", with different values within 15 seconds.

After some digging i found that Thread.Abort() throws exception : System.PlatformNotSupportedException: Thread abort is not supported on this platform.

Here's the fix i applied on my branch, i hope it can help.

Thanks

Matthieu